### PR TITLE
Do not bind keys on load

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,8 +16,6 @@ Place kpm-list.el into an emacs load-path and require the feature `kpm-list`. Fo
     (push "~/emacs.d" load-path)
     (require 'kpm-list)
 
-This will override your C-x C-b key.
-
 ## Improvements to be made
 
 * I would like to display the buffers grouped together by directory as a fancy-pants tree.

--- a/kpm-list.el
+++ b/kpm-list.el
@@ -414,11 +414,6 @@
 (define-derived-mode kpm-list-mode special-mode "Grouped Buffer List"
   "Major mode for editing a list of open buffers.")
 
-
-;;; Misc. ------------------------------------------------------------
-
-(global-set-key (kbd "C-x C-b") 'kpm-list)
-
 (provide 'kpm-list)
 
 ;;; kpm-list.el ends here


### PR DESCRIPTION
Setting user keybindings on load is inappropriate. For just on example, consider cases where this development may be a dependency of another package.
